### PR TITLE
feat(proto): add external_reference and reason to Payout and InternalTransfer events

### DIFF
--- a/proto/nutmeg/user_event.proto
+++ b/proto/nutmeg/user_event.proto
@@ -44,6 +44,8 @@ message Payout {
   string currency = 6;
   string provider = 7;
   PayoutBeneficiary beneficiary = 8;
+  string external_reference = 9;
+  optional string reason = 10;
 }
 
 message PayoutBeneficiary {
@@ -87,5 +89,7 @@ message InternalTransfer {
   string base_currency = 6;
   string quote_currency = 7;
   User beneficiary = 8;
+  string external_reference = 9;
+  optional string reason = 10;
 }
 


### PR DESCRIPTION
## Summary
- Add `external_reference` (string) field to `Payout` and `InternalTransfer` messages in `user_event.proto`
- Add `optional string reason` field to `Payout` and `InternalTransfer` messages
- Regenerated Go and Node.js code

## Test plan
- [ ] Verify generated Go code compiles
- [ ] Verify generated JS/TS types are correct
- [ ] Confirm downstream services handle new optional fields gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)